### PR TITLE
Automatically decode from pathnames/streams in `jget`.

### DIFF
--- a/functions.lisp
+++ b/functions.lisp
@@ -112,6 +112,10 @@ CHAR is left unread on STREAM after returning."
     (cerror "Return nothing"
             'non-indexable :value object)
     (values nil nil))
+  (:method (key (object pathname))
+    (jget* key (decode-from-file object)))
+  (:method (key (object stream))
+    (jget* key (decode-from-stream object)))
   (:method ((key string) (object string))
     (declare (ignore key))
     (cerror "Return nothing"


### PR DESCRIPTION
This way, it's easier for quick-and-dirty JSON indexing on files and streams, without the need to parse them first.

String-parsing is not supported due to it being ambiguous:
- Is it a string to be parsed and then acted upon?
- Or is it a string that is erroneously indexed with wrong indices?

Closes #15.